### PR TITLE
feat: 支持 github 风格的 footnote 

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -9,7 +9,7 @@ import markdownItImsize from "markdown-it-imsize";
 
 import markdownItSpan from "./markdown-it-span";
 import markdownItTableContainer from "./markdown-it-table-container";
-import markdownItLinkfoot from "./markdown-it-linkfoot";
+import markdownItLinkfoot from "markdown-it-linkfoot";
 import markdownItImageFlow from "./markdown-it-imageflow";
 import markdownItMultiquote from "./markdown-it-multiquote";
 import highlightjs from "./langHighlight";

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -9,8 +9,8 @@ import markdownItImsize from "markdown-it-imsize";
 
 import markdownItSpan from "./markdown-it-span";
 import markdownItTableContainer from "./markdown-it-table-container";
-// import markdownItLinkfoot from "./markdown-it-linkfoot";
-import markdownItFootNote from "markdown-it-footnote";
+import markdownItLinkfoot from "./markdown-it-linkfoot";
+// import markdownItFootNote from "markdown-it-footnote";
 import markdownItImageFlow from "./markdown-it-imageflow";
 import markdownItMultiquote from "./markdown-it-multiquote";
 import highlightjs from "./langHighlight";
@@ -83,7 +83,8 @@ markdownParser
   .use(markdownItSpan) // 在标题标签中添加span
   .use(markdownItTableContainer) // 在表格外部添加容器
   .use(markdownItMath) // 数学公式
-  .use(markdownItFootNote) // 修改脚注
+  .use(markdownItLinkfoot) // 修改脚注
+  // .use(markdownItFootNote) // 修改脚注
   .use(markdownItTableOfContents, {
     transformLink: () => "",
     includeLevel: [2, 3],

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -9,7 +9,8 @@ import markdownItImsize from "markdown-it-imsize";
 
 import markdownItSpan from "./markdown-it-span";
 import markdownItTableContainer from "./markdown-it-table-container";
-import markdownItLinkfoot from "markdown-it-linkfoot";
+// import markdownItLinkfoot from "./markdown-it-linkfoot";
+import markdownItFootNote from "markdown-it-footnote";
 import markdownItImageFlow from "./markdown-it-imageflow";
 import markdownItMultiquote from "./markdown-it-multiquote";
 import highlightjs from "./langHighlight";
@@ -82,7 +83,7 @@ markdownParser
   .use(markdownItSpan) // 在标题标签中添加span
   .use(markdownItTableContainer) // 在表格外部添加容器
   .use(markdownItMath) // 数学公式
-  .use(markdownItLinkfoot) // 修改脚注
+  .use(markdownItFootNote) // 修改脚注
   .use(markdownItTableOfContents, {
     transformLink: () => "",
     includeLevel: [2, 3],

--- a/src/utils/markdown-it-linkfoot.js
+++ b/src/utils/markdown-it-linkfoot.js
@@ -1,369 +1,367 @@
-function renderFootnoteAnchorName(tokens, idx, options, env) {
-  const n = Number(tokens[idx].meta.id + 1).toString();
-  let prefix = "";
+// Process footnotes
+//
+'use strict';
 
-  if (typeof env.docId === "string") {
-    prefix = "-" + env.docId + "-";
+////////////////////////////////////////////////////////////////////////////////
+// Renderer partials
+
+function render_footnote_anchor_name(tokens, idx, options, env/*, slf*/) {
+  var n = Number(tokens[idx].meta.id + 1).toString();
+  var prefix = '';
+
+  if (typeof env.docId === 'string') {
+    prefix = '-' + env.docId + '-';
   }
 
   return prefix + n;
 }
 
-function renderFootnoteCaption(tokens, idx) {
-  let n = Number(tokens[idx].meta.id + 1).toString();
+function render_footnote_caption(tokens, idx/*, options, env, slf*/) {
+  var n = Number(tokens[idx].meta.id + 1).toString();
 
   if (tokens[idx].meta.subId > 0) {
-    n += ":" + tokens[idx].meta.subId;
+    n += ':' + tokens[idx].meta.subId;
   }
 
-  return "[" + n + "]";
+  return '[' + n + ']';
 }
 
-// eslint-disable-next-line
-function renderFootnoteWord(tokens, idx, options, env, slf) {
-  return '<span class="footnote-word">' + tokens[idx].content + "</span>";
-}
-
-function renderFootnoteRef(tokens, idx, options, env, slf) {
-  // var id      = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
-  const caption = slf.rules.footnote_caption(tokens, idx, options, env, slf);
-  return '<sup class="footnote-ref">' + caption + "</sup>";
-}
-
-// eslint-disable-next-line
-function renderFootnoteBlockOpen(tokens, idx, options) {
-  return '<h3 class="footnotes-sep"></h3>\n<section class="footnotes">\n';
-}
-
-function renderFootnoteBlockClose() {
-  return "</section>\n";
-}
-
-function renderFootnoteOpen(tokens, idx, options, env, slf) {
-  let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
+function render_footnote_ref(tokens, idx, options, env, slf) {
+  var id      = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
+  var caption = slf.rules.footnote_caption(tokens, idx, options, env, slf);
+  var refid   = id;
 
   if (tokens[idx].meta.subId > 0) {
-    id += ":" + tokens[idx].meta.subId;
+    refid += ':' + tokens[idx].meta.subId;
   }
 
-  return '<span id="fn' + id + '" class="footnote-item"><span class="footnote-num">[' + id + "] </span>";
+  return '<sup class="footnote-ref">' + caption + '</sup>';
 }
 
-function renderFootnoteClose() {
-  return "</span>\n";
+function render_footnote_block_open(tokens, idx, options) {
+  return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
+      '<section class="footnotes">\n' +
+      '<ol class="footnotes-list">\n';
 }
 
-// Process [link](<to> "stuff")
-function isSpace(code) {
-  switch (code) {
-    case 0x09:
-    case 0x20:
-      return true;
-    default:
-  }
-  return false;
+function render_footnote_block_close() {
+  return '</ol>\n</section>\n';
 }
 
-function normalizeReference(str) {
-  // use .toUpperCase() instead of .toLowerCase()
-  // here to avoid a conflict with Object.prototype
-  // members (most notably, `__proto__`)
-  return str
-    .trim()
-    .replace(/\s+/g, " ")
-    .toUpperCase();
+function render_footnote_open(tokens, idx, options, env, slf) {
+  var id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
+
+  if (tokens[idx].meta.subId > 0) {
+    id += ':' + tokens[idx].meta.subId;
+  }
+
+  return '<li id="fn' + id + '" class="footnote-item">';
 }
 
-function linkFoot(state, silent) {
-  let attrs,
-    code,
-    label,
-    pos,
-    res,
-    ref,
-    title,
-    token,
-    href = "",
-    start = state.pos,
-    footnoteContent,
-    parseReference = true;
-  const oldPos = state.pos;
-  const max = state.posMax;
-
-  if (state.src.charCodeAt(state.pos) !== 0x5b /* [ */) {
-    return false;
-  }
-
-  const labelStart = state.pos + 1;
-  const labelEnd = state.md.helpers.parseLinkLabel(state, state.pos, true);
-
-  // parser failed to find ']', so it's not a valid link
-  if (labelEnd < 0) {
-    return false;
-  }
-
-  pos = labelEnd + 1;
-  if (pos < max && state.src.charCodeAt(pos) === 0x28 /* ( */) {
-    //
-    // Inline link
-    //
-
-    // might have found a valid shortcut link, disable reference parsing
-    parseReference = false;
-
-    // [link](  <href>  "title"  )
-    //        ^^ skipping these spaces
-    pos++;
-    for (; pos < max; pos++) {
-      code = state.src.charCodeAt(pos);
-      if (!isSpace(code) && code !== 0x0a) {
-        break;
-      }
-    }
-    if (pos >= max) {
-      return false;
-    }
-
-    // [link](  <href>  "title"  )
-    //          ^^^^^^ parsing link destination
-    start = pos;
-    res = state.md.helpers.parseLinkDestination(state.src, pos, state.posMax);
-    if (res.ok) {
-      href = state.md.normalizeLink(res.str);
-      footnoteContent = res.str;
-      if (state.md.validateLink(href)) {
-        pos = res.pos;
-      } else {
-        href = "";
-      }
-    }
-
-    // [link](  <href>  "title"  )
-    //                ^^ skipping these spaces
-    start = pos;
-    for (; pos < max; pos++) {
-      code = state.src.charCodeAt(pos);
-      if (!isSpace(code) && code !== 0x0a) {
-        break;
-      }
-    }
-
-    // [link](  <href>  "title"  )
-    //                  ^^^^^^^ parsing link title
-    res = state.md.helpers.parseLinkTitle(state.src, pos, state.posMax);
-    if (pos < max && start !== pos && res.ok) {
-      title = res.str;
-      pos = res.pos;
-
-      // [link](  <href>  "title"  )
-      //                         ^^ skipping these spaces
-      for (; pos < max; pos++) {
-        code = state.src.charCodeAt(pos);
-        if (!isSpace(code) && code !== 0x0a) {
-          break;
-        }
-      }
-    } else {
-      title = "";
-    }
-
-    if (pos >= max || state.src.charCodeAt(pos) !== 0x29 /* ) */) {
-      // parsing a valid shortcut link failed, fallback to reference
-      parseReference = true;
-    }
-    pos++;
-  }
-
-  if (parseReference) {
-    //
-    // Link reference
-    //
-    if (typeof state.env.references === "undefined") {
-      return false;
-    }
-
-    if (pos < max && state.src.charCodeAt(pos) === 0x5b /* [ */) {
-      start = pos + 1;
-      pos = state.md.helpers.parseLinkLabel(state, pos);
-      if (pos >= 0) {
-        label = state.src.slice(start, pos++);
-      } else {
-        pos = labelEnd + 1;
-      }
-    } else {
-      pos = labelEnd + 1;
-    }
-
-    // covers label === '' and label === undefined
-    // (collapsed reference link and shortcut reference link respectively)
-    if (!label) {
-      label = state.src.slice(labelStart, labelEnd);
-    }
-
-    ref = state.env.references[normalizeReference(label)];
-    if (!ref) {
-      state.pos = oldPos;
-      return false;
-    }
-    href = ref.href;
-    title = ref.title;
-  }
-
-  //
-  // We found the end of the link, and know for a fact it's a valid link;
-  // so all that's left to do is to call tokenizer.
-  //
-  if (!silent) {
-    // 如果存在标题则转成脚注
-    if (title) {
-      state.pos = labelStart;
-      state.posMax = labelEnd;
-
-      let tokens;
-
-      if (!state.env.footnotes) {
-        state.env.footnotes = {};
-      }
-      if (!state.env.footnotes.list) {
-        state.env.footnotes.list = [];
-      }
-
-      const footnoteId = state.env.footnotes.list.length;
-
-      // *用来让链接倾斜
-      state.md.inline.parse(`${title}: *${footnoteContent}*`, state.md, state.env, (tokens = []));
-
-      token = state.push("footnote_word", "", 0);
-      token.content = state.src.slice(labelStart, labelEnd);
-
-      token = state.push("footnote_ref", "", 0);
-      token.meta = {id: footnoteId};
-
-      state.env.footnotes.list[footnoteId] = {tokens: tokens};
-    }
-    // 不存在标题则判断域名
-    else {
-      state.pos = labelStart;
-      state.posMax = labelEnd;
-
-      token = state.push("link_open", "a", 1);
-      attrs = [["href", href]];
-      token.attrs = attrs;
-      if (title) {
-        attrs.push(["title", title]);
-      }
-
-      state.md.inline.tokenize(state);
-
-      token = state.push("link_close", "a", -1);
-    }
-  }
-
-  state.pos = pos;
-  state.posMax = max;
-
-  return true;
+function render_footnote_close() {
+  return '</li>\n';
 }
 
-// Glue footnote tokens to end of token stream
-function footnoteTail(state) {
-  var i,
-    l,
-    lastParagraph,
-    list,
-    token,
-    tokens,
-    current,
-    currentLabel,
-    insideRef = false,
-    refTokens = {};
+function render_footnote_anchor(tokens, idx, options, env, slf) {
+  var id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
 
-  if (!state.env.footnotes) {
-    return;
+  if (tokens[idx].meta.subId > 0) {
+    id += ':' + tokens[idx].meta.subId;
   }
 
-  state.tokens = state.tokens.filter((tok) => {
-    if (tok.type === "footnote_reference_open") {
-      insideRef = true;
-      current = [];
-      currentLabel = tok.meta.label;
-      return false;
-    }
-    if (tok.type === "footnote_reference_close") {
-      insideRef = false;
-      // prepend ':' to avoid conflict with Object.prototype members
-      refTokens[":" + currentLabel] = current;
-      return false;
-    }
-    if (insideRef) {
-      current.push(tok);
-    }
-    return !insideRef;
-  });
-
-  if (!state.env.footnotes.list) {
-    return;
-  }
-  list = state.env.footnotes.list;
-
-  token = new state.Token("footnote_block_open", "", 1);
-  state.tokens.push(token);
-
-  for (i = 0, l = list.length; i < l; i++) {
-    token = new state.Token("footnote_open", "", 1);
-    token.meta = {id: i, label: list[i].label};
-    state.tokens.push(token);
-
-    if (list[i].tokens) {
-      tokens = [];
-
-      token = new state.Token("paragraph_open", "p", 1);
-      token.block = true;
-      tokens.push(token);
-
-      token = new state.Token("inline", "", 0);
-      token.children = list[i].tokens;
-      token.content = "";
-      tokens.push(token);
-
-      token = new state.Token("paragraph_close", "p", -1);
-      token.block = true;
-      tokens.push(token);
-    } else if (list[i].label) {
-      tokens = refTokens[":" + list[i].label];
-    }
-
-    state.tokens = state.tokens.concat(tokens);
-    if (state.tokens[state.tokens.length - 1].type === "paragraph_close") {
-      lastParagraph = state.tokens.pop();
-    } else {
-      lastParagraph = null;
-    }
-
-    if (lastParagraph) {
-      state.tokens.push(lastParagraph);
-    }
-
-    token = new state.Token("footnote_close", "", -1);
-    state.tokens.push(token);
-  }
-
-  token = new state.Token("footnote_block_close", "", -1);
-  state.tokens.push(token);
+  /* ↩ with escape code to prevent display as Apple Emoji on iOS */
+  return ' \u21a9\uFE0E';
 }
 
-export default (md) => {
-  md.renderer.rules.footnote_ref = renderFootnoteRef;
-  md.renderer.rules.footnote_word = renderFootnoteWord;
-  md.renderer.rules.footnote_block_open = renderFootnoteBlockOpen;
-  md.renderer.rules.footnote_block_close = renderFootnoteBlockClose;
-  md.renderer.rules.footnote_open = renderFootnoteOpen;
-  md.renderer.rules.footnote_close = renderFootnoteClose;
+
+module.exports = function footnote_plugin(md) {
+  var parseLinkLabel = md.helpers.parseLinkLabel,
+      isSpace = md.utils.isSpace;
+
+  md.renderer.rules.footnote_ref          = render_footnote_ref;
+  md.renderer.rules.footnote_block_open   = render_footnote_block_open;
+  md.renderer.rules.footnote_block_close  = render_footnote_block_close;
+  md.renderer.rules.footnote_open         = render_footnote_open;
+  md.renderer.rules.footnote_close        = render_footnote_close;
+  md.renderer.rules.footnote_anchor       = render_footnote_anchor;
 
   // helpers (only used in other rules, no tokens are attached to those)
-  md.renderer.rules.footnote_caption = renderFootnoteCaption;
-  md.renderer.rules.footnote_anchor_name = renderFootnoteAnchorName;
+  md.renderer.rules.footnote_caption      = render_footnote_caption;
+  md.renderer.rules.footnote_anchor_name  = render_footnote_anchor_name;
 
-  md.inline.ruler.at("link", linkFoot);
-  md.core.ruler.after("inline", "footnote_tail", footnoteTail);
+  // Process footnote block definition
+  function footnote_def(state, startLine, endLine, silent) {
+    var oldBMark, oldTShift, oldSCount, oldParentType, pos, label, token,
+        initial, offset, ch, posAfterColon,
+        start = state.bMarks[startLine] + state.tShift[startLine],
+        max = state.eMarks[startLine];
+
+    // line should be at least 5 chars - "[^x]:"
+    if (start + 4 > max) { return false; }
+
+    if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
+    if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
+
+    for (pos = start + 2; pos < max; pos++) {
+      if (state.src.charCodeAt(pos) === 0x20) { return false; }
+      if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
+        break;
+      }
+    }
+
+    if (pos === start + 2) { return false; } // no empty footnote labels
+    if (pos + 1 >= max || state.src.charCodeAt(++pos) !== 0x3A /* : */) { return false; }
+    if (silent) { return true; }
+    pos++;
+
+    if (!state.env.footnotes) { state.env.footnotes = {}; }
+    if (!state.env.footnotes.refs) { state.env.footnotes.refs = {}; }
+    label = state.src.slice(start + 2, pos - 2);
+    state.env.footnotes.refs[':' + label] = -1;
+
+    token       = new state.Token('footnote_reference_open', '', 1);
+    token.meta  = { label: label };
+    token.level = state.level++;
+    state.tokens.push(token);
+
+    oldBMark = state.bMarks[startLine];
+    oldTShift = state.tShift[startLine];
+    oldSCount = state.sCount[startLine];
+    oldParentType = state.parentType;
+
+    posAfterColon = pos;
+    initial = offset = state.sCount[startLine] + pos - (state.bMarks[startLine] + state.tShift[startLine]);
+
+    while (pos < max) {
+      ch = state.src.charCodeAt(pos);
+
+      if (isSpace(ch)) {
+        if (ch === 0x09) {
+          offset += 4 - offset % 4;
+        } else {
+          offset++;
+        }
+      } else {
+        break;
+      }
+
+      pos++;
+    }
+
+    state.tShift[startLine] = pos - posAfterColon;
+    state.sCount[startLine] = offset - initial;
+
+    state.bMarks[startLine] = posAfterColon;
+    state.blkIndent += 4;
+    state.parentType = 'footnote';
+
+    if (state.sCount[startLine] < state.blkIndent) {
+      state.sCount[startLine] += state.blkIndent;
+    }
+
+    state.md.block.tokenize(state, startLine, endLine, true);
+
+    state.parentType = oldParentType;
+    state.blkIndent -= 4;
+    state.tShift[startLine] = oldTShift;
+    state.sCount[startLine] = oldSCount;
+    state.bMarks[startLine] = oldBMark;
+
+    token       = new state.Token('footnote_reference_close', '', -1);
+    token.level = --state.level;
+    state.tokens.push(token);
+
+    return true;
+  }
+
+  // Process inline footnotes (^[...])
+  function footnote_inline(state, silent) {
+    var labelStart,
+        labelEnd,
+        footnoteId,
+        token,
+        tokens,
+        max = state.posMax,
+        start = state.pos;
+
+    if (start + 2 >= max) { return false; }
+    if (state.src.charCodeAt(start) !== 0x5E/* ^ */) { return false; }
+    if (state.src.charCodeAt(start + 1) !== 0x5B/* [ */) { return false; }
+
+    labelStart = start + 2;
+    labelEnd = parseLinkLabel(state, start + 1);
+
+    // parser failed to find ']', so it's not a valid note
+    if (labelEnd < 0) { return false; }
+
+    // We found the end of the link, and know for a fact it's a valid link;
+    // so all that's left to do is to call tokenizer.
+    //
+    if (!silent) {
+      if (!state.env.footnotes) { state.env.footnotes = {}; }
+      if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
+      footnoteId = state.env.footnotes.list.length;
+
+      state.md.inline.parse(
+          state.src.slice(labelStart, labelEnd),
+          state.md,
+          state.env,
+          tokens = []
+      );
+
+      token      = state.push('footnote_ref', '', 0);
+      token.meta = { id: footnoteId };
+
+      state.env.footnotes.list[footnoteId] = {
+        content: state.src.slice(labelStart, labelEnd),
+        tokens: tokens
+      };
+    }
+
+    state.pos = labelEnd + 1;
+    state.posMax = max;
+    return true;
+  }
+
+  // Process footnote references ([^...])
+  function footnote_ref(state, silent) {
+    var label,
+        pos,
+        footnoteId,
+        footnoteSubId,
+        token,
+        max = state.posMax,
+        start = state.pos;
+
+    // should be at least 4 chars - "[^x]"
+    if (start + 3 > max) { return false; }
+
+    if (!state.env.footnotes || !state.env.footnotes.refs) { return false; }
+    if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
+    if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
+
+    for (pos = start + 2; pos < max; pos++) {
+      if (state.src.charCodeAt(pos) === 0x20) { return false; }
+      if (state.src.charCodeAt(pos) === 0x0A) { return false; }
+      if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
+        break;
+      }
+    }
+
+    if (pos === start + 2) { return false; } // no empty footnote labels
+    if (pos >= max) { return false; }
+    pos++;
+
+    label = state.src.slice(start + 2, pos - 1);
+    if (typeof state.env.footnotes.refs[':' + label] === 'undefined') { return false; }
+
+    if (!silent) {
+      if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
+
+      if (state.env.footnotes.refs[':' + label] < 0) {
+        footnoteId = state.env.footnotes.list.length;
+        state.env.footnotes.list[footnoteId] = { label: label, count: 0 };
+        state.env.footnotes.refs[':' + label] = footnoteId;
+      } else {
+        footnoteId = state.env.footnotes.refs[':' + label];
+      }
+
+      footnoteSubId = state.env.footnotes.list[footnoteId].count;
+      state.env.footnotes.list[footnoteId].count++;
+
+      token      = state.push('footnote_ref', '', 0);
+      token.meta = { id: footnoteId, subId: footnoteSubId, label: label };
+    }
+
+    state.pos = pos;
+    state.posMax = max;
+    return true;
+  }
+
+  // Glue footnote tokens to end of token stream
+  function footnote_tail(state) {
+    var i, l, j, t, lastParagraph, list, token, tokens, current, currentLabel,
+        insideRef = false,
+        refTokens = {};
+
+    if (!state.env.footnotes) { return; }
+
+    state.tokens = state.tokens.filter(function (tok) {
+      if (tok.type === 'footnote_reference_open') {
+        insideRef = true;
+        current = [];
+        currentLabel = tok.meta.label;
+        return false;
+      }
+      if (tok.type === 'footnote_reference_close') {
+        insideRef = false;
+        // prepend ':' to avoid conflict with Object.prototype members
+        refTokens[':' + currentLabel] = current;
+        return false;
+      }
+      if (insideRef) { current.push(tok); }
+      return !insideRef;
+    });
+
+    if (!state.env.footnotes.list) { return; }
+    list = state.env.footnotes.list;
+
+    token = new state.Token('footnote_block_open', '', 1);
+    state.tokens.push(token);
+
+    for (i = 0, l = list.length; i < l; i++) {
+      token      = new state.Token('footnote_open', '', 1);
+      token.meta = { id: i, label: list[i].label };
+      state.tokens.push(token);
+
+      if (list[i].tokens) {
+        tokens = [];
+
+        token          = new state.Token('paragraph_open', 'p', 1);
+        token.block    = true;
+        tokens.push(token);
+
+        token          = new state.Token('inline', '', 0);
+        token.children = list[i].tokens;
+        token.content  = list[i].content;
+        tokens.push(token);
+
+        token          = new state.Token('paragraph_close', 'p', -1);
+        token.block    = true;
+        tokens.push(token);
+
+      } else if (list[i].label) {
+        tokens = refTokens[':' + list[i].label];
+      }
+
+      if (tokens) state.tokens = state.tokens.concat(tokens);
+      if (state.tokens[state.tokens.length - 1].type === 'paragraph_close') {
+        lastParagraph = state.tokens.pop();
+      } else {
+        lastParagraph = null;
+      }
+
+      t = list[i].count > 0 ? list[i].count : 1;
+      for (j = 0; j < t; j++) {
+        token      = new state.Token('footnote_anchor', '', 0);
+        token.meta = { id: i, subId: j, label: list[i].label };
+        state.tokens.push(token);
+      }
+
+      if (lastParagraph) {
+        state.tokens.push(lastParagraph);
+      }
+
+      token = new state.Token('footnote_close', '', -1);
+      state.tokens.push(token);
+    }
+
+    token = new state.Token('footnote_block_close', '', -1);
+    state.tokens.push(token);
+  }
+
+  md.block.ruler.before('reference', 'footnote_def', footnote_def, { alt: [ 'paragraph', 'reference' ] });
+  md.inline.ruler.after('image', 'footnote_inline', footnote_inline);
+  md.inline.ruler.after('footnote_inline', 'footnote_ref', footnote_ref);
+  md.core.ruler.after('inline', 'footnote_tail', footnote_tail);
 };


### PR DESCRIPTION
在自己的博客中，经常使用的 footnote 风格是 github style[^1] 的 footnote，但是 mdnice 并不支持这种风格 https://github.com/mdnice/markdown-nice/issues/52

mdnice 是一个非常优秀的多平台渲染工具，但是自己确实不适应 `[](link "脚注")` 这种风格的 footnote，因此魔改了官方的 markdown-it-footnote plugin，实际代码变动并不大，参考 https://github.com/librabyte/markdown-it-footnote/pull/1 

[^1]: https://github.blog/changelog/2021-09-30-footnotes-now-supported-in-markdown-fields/